### PR TITLE
Fix OG metadata

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -92,6 +92,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'oauth2_provider.middleware.OAuth2TokenMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
 )
 
 # MIGRATIONS CONFIGURATION

--- a/config/urls.py
+++ b/config/urls.py
@@ -9,6 +9,7 @@ from django.views import defaults as default_views
 from django.views.generic import TemplateView
 from rest_framework import routers
 
+from mad_web import pages
 from mad_web.events.views import EventViewSet
 from mad_web.madcon.views import MyRegistrationViewSet, MADconViewSet, RegistrationViewSet
 from mad_web.users.views import UserViewSet, MeView
@@ -20,11 +21,8 @@ router.register(r'madcon/myregistration', MyRegistrationViewSet)
 router.register(r'madcon/registration', RegistrationViewSet)
 router.register(r'madcon', MADconViewSet)
 
-
 urlpatterns = [
-                  url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name='about'),
-                  url(r'^workshops/$', TemplateView.as_view(template_name='pages/workshops.html'), name='workshops'),
-                  url(r'^labs/$', TemplateView.as_view(template_name='pages/labs.html'), name='labs'),
+                  url(r'^', include('mad_web.pages.urls')),
                   # Django Admin, use {% url 'admin:index' %}
                   url(settings.ADMIN_URL, include(admin.site.urls)),
 
@@ -47,7 +45,7 @@ urlpatterns = [
                   url(r'^go/', include('mad_web.go.urls', namespace='go')),
                   url(r'^notify/', include('mad_web.notify.urls', namespace='notify')),
 
-                  #OAuth
+                  # OAuth
                   url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider'))
 
               ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/mad_web/contrib/sites/migrations/0004_set_domain_and_name.py
+++ b/mad_web/contrib/sites/migrations/0004_set_domain_and_name.py
@@ -1,0 +1,38 @@
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations
+
+
+def update_site_forward(apps, schema_editor):
+    """Set site domain and name."""
+    Site = apps.get_model('sites', 'Site')
+    Site.objects.update_or_create(
+        id=settings.SITE_ID,
+        defaults={
+            'domain': 'www.txcsmad.com',
+            'name': 'MAD Web'
+        }
+    )
+
+
+def update_site_backward(apps, schema_editor):
+    """Revert site domain and name to default."""
+    Site = apps.get_model('sites', 'Site')
+    Site.objects.update_or_create(
+        id=settings.SITE_ID,
+        defaults={
+            'domain': 'example.com',
+            'name': 'example.com'
+        }
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sites', '0003_auto_20160731_1740'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_site_forward, update_site_backward),
+    ]

--- a/mad_web/pages/urls.py
+++ b/mad_web/pages/urls.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.conf.urls import url
+from django.views.generic import TemplateView
+
+from . import views
+
+urlpatterns = [
+    url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name='about'),
+    url(r'^workshops/$', TemplateView.as_view(template_name='pages/workshops.html'), name='workshops'),
+    url(r'^labs/$', TemplateView.as_view(template_name='pages/labs.html'), {'description': 'MAD Labs is a subset of the most technically experienced and passionate MAD members that focuses on creating quality mobile apps for others. Members specialize in iOS, Android, Windows or web platforms.'}, name='labs'),
+]

--- a/mad_web/templates/base.html
+++ b/mad_web/templates/base.html
@@ -6,23 +6,21 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}MAD{% endblock title %}</title>
     <meta name="description"
-          content="Mobile App Development, UT Austin's premiere student organization dedicated to mobile platforms. ">
+          content="{{ description|default:"Mobile App Development, UT Austin's premiere student organization dedicated to mobile platforms."}}">
     <meta name="theme-color" content="#1EBD5F">
 
     <!-- SEO -->
-    <meta property="og:title" content="MAD">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.txcsmad.com">
-    <meta property="og:image" content="
-            {{ request.build_absolute_uri }}{% block open_graph_image %}{% static 'images/mad-logo-banner-color.png' %}{% endblock open_graph_image %}"/>
+    <meta property="og:url" content="https://{{ request.site.domain }}">
+    <meta property="og:image" content="https://{{ request.site.domain }}{% block open_graph_image %}{% static 'images/mad-logo-banner-color.png' %}{% endblock open_graph_image %}"/>
     <meta property="og:site_name" content="txcsmad.com">
     <meta property="og:description"
-          content="Mobile App Development, UT Austin's premiere student organization dedicated to mobile platforms.">
+          content="{{ description|default:"Mobile App Development, UT Austin's premiere student organization dedicated to mobile platforms."}}">
     <meta name="keywords" content="mobile, app, applications, development, education, UT, austin">
-    <link rel="canonical" href="https://www.txcsmad.com/">
+    <link rel="canonical" href="https://{{ request.site.domain }}{{ request.path }}">
 
     <!-- Mobile Metas -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Favicons -->
     <link rel="icon" type="image/png" sizes="196x196" href="{% static 'images/icons/favicon-196.png' %}">


### PR DESCRIPTION
This addresses some of the weirdness with the Facebook share preview. It removes the `og:title` tag, allowing the regular title tag to provide the information. This prevents us from having to refactor away from block inheritance just so we can put the same information in two places at once.

This also creates a `pages` app to hold their url config and some variables that get passed in.