### PR TITLE
Border added to matched machines

### DIFF
--- a/mad_web/static/js/labstatus/search.js
+++ b/mad_web/static/js/labstatus/search.js
@@ -7,7 +7,9 @@ function filterMachines(machines, filterString) {
         const match = name.indexOf(filterString.toLowerCase()) > -1;
         if (!match) {
             machine.addClass("no-match")
+            machine.removeClass("match-highlight")
         } else {
+            machine.addClass("match-highlight")
             machine.removeClass("no-match")
         }
     });

--- a/mad_web/static/sass/labstatus/labstatus.scss
+++ b/mad_web/static/sass/labstatus/labstatus.scss
@@ -160,6 +160,11 @@ input[type="search"]::-webkit-search-results-decoration {
   opacity: .5;
 }
 
+.match-highlight {
+    border-style: solid;
+    border-color: #0046ff;
+}
+
 #help-icon {
   display: inline-block;
 }


### PR DESCRIPTION
It was sort of hard to notice on mobile when a machine did and didn't match despite the opacity, so this adds a solid blue border to matched machines. The border can be any color, I just chose blue because I thought it didn't look awful and it stands out.